### PR TITLE
css3 selector-pseudo-element-colon-notation std

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -45,7 +45,7 @@ rules:
   selector-pseudo-class-no-unknown: true
   selector-pseudo-class-parentheses-space-inside: never
   selector-pseudo-element-case: lower
-  selector-pseudo-element-colon-notation: null
+  selector-pseudo-element-colon-notation: double
   selector-pseudo-element-no-unknown: true
   selector-type-case: lower
   selector-type-no-unknown: true


### PR DESCRIPTION
https://www.w3.org/TR/selectors/#pseudo-elements

All our styles default css uses double our styles its a mixed bag in some, would be better like this.